### PR TITLE
Dockerfile was out-of-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ We suggest building environment via docker or conda or using platforms with tens
 ### Build environment from docker file (Optional)
 We provide a Dockerfile which directly sets up the tensorflow and relevant package. More information about docker can be found [here](https://www.docker.com/). 
 The prerequisite for using the docker can be found [here](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorflow).
-After prerequisite is satisfied, you can download the dockerfile [here](https://drive.google.com/file/d/1SlUNKthEDH_RuTkDI02g8bmZa0lig7BL/view?usp=sharing)
+After prerequisite is satisfied, you can use the dockerfile [here](docker_build/Dockerfile)
 Run the following to build a docker image
 ```bash
-mkdir docker_build
 cd docker_build
 ```
 ```bash

--- a/docker_build/Dockerfile
+++ b/docker_build/Dockerfile
@@ -1,0 +1,5 @@
+# For building docker image for MIND
+FROM tensorflow/tensorflow:2.11.0-gpu
+
+RUN pip3 install numpy==1.23.5 Biopython==1.81 spektral==1.2.0 tensorflow==2.11.0 matplotlib seaborn
+


### PR DESCRIPTION
Previous version of Dockerfile (was in Google Drive) was out of date, and the TF version mismatches with the saved model parameters (hence did not work). This PR updates the Dockerfile to match with `requirements` file, and adds Dockerfile to the repository instead of downloading from Google Drive.